### PR TITLE
feat: add basic file overwrite implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Additionally you need to enable the Google Drive API for your GCP project. Do th
 
 ## Simple Workflow
 In this example we stored the folderId and credentials as action secrets. This is highly recommended as leaking your credentials key will allow anyone to use your service account.
+
 ```yaml
 # .github/workflows/main.yml
 name: Main
@@ -94,3 +95,8 @@ This string should be base64 encoded. If it is not, set the `encoded` input to `
 Required: **NO**
 
 Whether or not the credentials string is base64 encoded. Defaults to `true`.
+
+## ``overwrite``
+Required: **NO**
+
+If you want to overwrite all existing files in the drive folder that match the given `name`, with the current file content. Defaults to `false`

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   encoded:
     description: 'true if the credentials are base64 encoded. false if they are not.'
     required: false
+  overwrite:
+    description: 'set to true to update an existing file with the same name, or false to create a new file.'
+    required: false
 
 runs:
   using: docker


### PR DESCRIPTION
Taking inspiration from PR #9 , mostly copy paste of @adityak74 's code
and addressing some of @Crejaud 's proposals to hopefully make a robust
first implementation

I've tested this feature locally, as well as from a github action (pointing at my branch), and it seems to work well

Note: I've been looking at adding some tests, by using a fake http server, as per
[google's api testing docs][google-testing-docs]; but, I might do this and any additional cleanup
or refactoring in separate PRs to reduce the scope of this one, and unblock
folks who need this feature and like using this package (like myself).

fixes #17

I've added 2 more follow up PRs, kept separately for shorter reviews:
* #21
* #22

[google-testing-docs]: https://github.com/googleapis/google-api-go-client/blob/cf0df64489c5086a57b9156d9648fe8342b22408/testing.md
